### PR TITLE
remove venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ Fork this repo, clone it locally, and change to the `/kmmo-downstream-docs-stagi
 cd ~/kmmo-downstream-docs-staging
 ```
 
-Create a Python virtual env (venv): 
-
-```cmd
-python3 -m venv venv
-source venv/bin/activate
-```
-
 Run the conversion:
 
 ```cmd


### PR DESCRIPTION
This PR removes the details about creating a python virtual environment from the README. It shouldn't be necessary if you install packages on the os.